### PR TITLE
Set platform to "Any CPU" on python project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,4 +3,4 @@ cmake_minimum_required(VERSION 3.8)
 project(CMakePTVS)
 
 add_subdirectory(CppProject)
-include_external_msproject(PyProject PyProject/PyProject.pyproj)
+include_external_msproject(PyProject PyProject/PyProject.pyproj PLATFORM "Any CPU")


### PR DESCRIPTION
By setting platform to "Any CPU" I was able to run the python project from Visual Studio 2019.

I used [this](https://github.com/microsoft/python-sample-vs-cpp-extension) project to guide me to the solution.